### PR TITLE
FaceID added to KeypadView. Biometry logic for CheckView.

### DIFF
--- a/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Demo/Demo.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/swiftui-introspect",
       "state" : {
-        "revision" : "ccb973cfff703cba53fb88197413485c060eb26b",
-        "version" : "0.10.0"
+        "revision" : "3ced72fccb284235c266c1e8a32f1bf93129fc74",
+        "version" : "1.1.0"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/divadretlaw/WindowReader",
       "state" : {
-        "revision" : "26fdb98bcc5f564a0d40bc6600aa718520e27925",
-        "version" : "1.0.2"
+        "revision" : "607785674f74a179ea8ce1c4a8aa6a255767f5c3",
+        "version" : "1.1.0"
       }
     },
     {
@@ -41,8 +41,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/divadretlaw/WindowSceneReader.git",
       "state" : {
-        "revision" : "3e39955e957b5e7011c94727ede4490cffa0ae28",
-        "version" : "2.0.0"
+        "revision" : "c4e3b7ceeb65dfed0fb05f739640cda45a67a5eb",
+        "version" : "2.1.0"
       }
     }
   ],

--- a/Sources/PasscodeKit/API.swift
+++ b/Sources/PasscodeKit/API.swift
@@ -103,10 +103,9 @@ public extension View {
     ///   - onCompletion: The closure to execute when the passcode was checked.
     func checkPasscode(
         isPresented: Binding<Bool>,
-        allowBiometrics: Bool = false,
         onCompletion: @escaping (Bool) -> Void
     ) -> some View {
-        modifier(PasscodeCheckViewModifier(isPresented: isPresented, allowBiometrics: allowBiometrics, onCompletion: onCompletion))
+        modifier(PasscodeCheckViewModifier(isPresented: isPresented, onCompletion: onCompletion))
     }
     
     /// Setup a passcode

--- a/Sources/PasscodeKit/PasscodeCheckViewModifier.swift
+++ b/Sources/PasscodeKit/PasscodeCheckViewModifier.swift
@@ -13,7 +13,6 @@ struct PasscodeCheckViewModifier: ViewModifier {
     @Environment(\.passcode.backgroundMaterial) private var backgroundMaterial
     
     @Binding var isPresented: Bool
-    var allowBiometrics: Bool = false
     var onCompletion: (Bool) -> Void
     
     func body(content: Content) -> some View {
@@ -27,7 +26,7 @@ struct PasscodeCheckViewModifier: ViewModifier {
                                     .background(material, ignoresSafeAreaEdges: .all)
                             }
                             
-                            PasscodeInputView(passcode: passcode, allowBiometrics: allowBiometrics, canCancel: true) { success in
+                            PasscodeInputView(passcode: passcode, allowBiometrics: passcode.isBiometricsEnabled, canCancel: true) { success in
                                 onCompletion(success)
                                 isPresented = false
                             }

--- a/Sources/PasscodeKit/Views/KeypadView.swift
+++ b/Sources/PasscodeKit/Views/KeypadView.swift
@@ -6,11 +6,16 @@
 //
 
 import SwiftUI
+import LocalAuthentication
 
 struct KeypadView: View {
+    
+    @Environment(\.passcode) private var passcodeEnv
     @Environment(\.passcode.keypadViewConfiguration) private var configuration
     
     @Binding var text: String
+    
+    var onBiometry: () -> Void
     
     var body: some View {
         VStack(alignment: .center, spacing: configuration.vSpacing) {
@@ -30,12 +35,40 @@ struct KeypadView: View {
                 NumberButton(value: .text("9"), text: $text)
             }
             HStack(spacing: configuration.hSpacing) {
-                NumberButton(value: .blank, text: $text)
-                    .hidden()
-                    .disabled(true)
+                if passcodeEnv.manager.passcode?.isBiometricsEnabled ?? false {
+                    Button {
+                        onBiometry()
+                    } label: {
+                        ZStack {
+                            Image(systemName: biometricsImage)
+                                .resizable()
+                                .foregroundColor(configuration.foregroundColor)
+                                .frame(maxWidth: 40, maxHeight: 40)
+                        }
+                        .foregroundStyle(.primary)
+                    }
+                    .buttonStyle(.plain)
+                    .frame(maxWidth: 100, maxHeight: 100)
+                } else {
+                    
+                    NumberButton(value: .blank, text: $text)
+                        .hidden()
+                        .disabled(true)
+                }
                 NumberButton(value: .text("0"), text: $text)
                 NumberButton(value: .delete, text: $text)
             }
+        }
+    }
+    
+    var biometricsImage: String {
+        switch LAContext().biometryType {
+        case .faceID:
+            return "faceid"
+        case .touchID:
+            return "touchid"
+        default:
+            return ""
         }
     }
 }
@@ -93,6 +126,6 @@ enum PasscodeInputValue: Hashable {
 
 struct KeypadView_Previews: PreviewProvider {
     static var previews: some View {
-        KeypadView(text: .constant(""))
+        KeypadView(text: .constant(""), onBiometry: {})
     }
 }


### PR DESCRIPTION
Hello @divadretlaw ,

During usage I have spotted few gaps.

1. On Check Modifier - we were relying on 
`allowBiometrics: Bool = false`
however it's more straight to use Passcode info. If we have biometry set we need to initiate check.

2. Have added FaceID/TouchID button to KeypadView since if Biometry fails we need a way to restart the process without code entering.

Open to any comments!