### PR TITLE
Re-enter password animation

### DIFF
--- a/Sources/PasscodeKit/Views/PasscodeSetupView.swift
+++ b/Sources/PasscodeKit/Views/PasscodeSetupView.swift
@@ -47,11 +47,11 @@ public struct PasscodeSetupView: View {
             case .initial:
                 inputView
                     .zIndex(0)
-                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
+                    //.transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .leading)))
             case .reEnter:
                 reEnterInputView
                     .zIndex(1)
-                    .transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .trailing)))
+                    //.transition(.asymmetric(insertion: .move(edge: .trailing), removal: .move(edge: .trailing)))
             }
         }
         .confirmationDialog(localizedBiometrics ?? "", isPresented: $showBiometrics, titleVisibility: localizedBiometrics != nil ? .visible : .hidden) {


### PR DESCRIPTION
@divadretlaw Slide transition for re-enter password looks a little bit off. Usually it just reloads the current view. At least banking apps and mail clients use this UX.

For now I've removed `.transition(.asymmetric(insertion:` but can redraw 'InternalPasscodeInputView'. What do you think?